### PR TITLE
project: Disposal and Unparent fixes

### DIFF
--- a/lib/Models/Bin.vala
+++ b/lib/Models/Bin.vala
@@ -49,9 +49,7 @@ public class He.Bin : Gtk.Widget, Gtk.Buildable {
     }
     
     construct {
-        var main_box = new Gtk.Box (Gtk.Orientation.VERTICAL, 0);
-        main_box.append (box);
-        main_box.set_parent (this);
+        box.set_parent (this);
     }
     
     static construct {
@@ -59,9 +57,11 @@ public class He.Bin : Gtk.Widget, Gtk.Buildable {
     }
 
     ~Bin () {
-        if (this.child != null) {
-            this.child.unparent ();
-        }
-        box.unparent ();
+      Gtk.Widget child;
+
+      while ((child = this.get_first_child ()) != null)
+        child.unparent ();
+
+      this.unparent ();
     }
 }

--- a/lib/Models/ButtonContent.vala
+++ b/lib/Models/ButtonContent.vala
@@ -68,6 +68,11 @@ public class He.ButtonContent : Gtk.Widget, Gtk.Buildable {
     }
 
     ~ButtonContent () {
-        box.unparent ();
+        Gtk.Widget child;
+
+        while ((child = this.get_first_child ()) != null)
+            child.unparent ();
+
+        this.unparent ();
     }
 }

--- a/lib/Models/View.vala
+++ b/lib/Models/View.vala
@@ -169,4 +169,13 @@ public abstract class He.View : Gtk.Widget, Gtk.Buildable {
 
         has_margins = true;
     }
+
+    ~View () {
+        Gtk.Widget child;
+
+        while ((child = this.get_first_child ()) != null)
+            child.unparent ();
+
+        this.unparent ();
+    }
 }

--- a/lib/Widgets/AboutWindow.vala
+++ b/lib/Widgets/AboutWindow.vala
@@ -347,11 +347,6 @@ public class He.AboutWindow : He.Window {
     this.set_child(window_handle);
   }
 
-  ~AboutWindow() {
-    this.unparent();
-    this.window_overlay.dispose();
-  }
-
   /**
   * Creates a new AboutWindow.
   * @param parent The parent window.

--- a/lib/Widgets/AppBar.vala
+++ b/lib/Widgets/AppBar.vala
@@ -347,8 +347,4 @@ public class He.AppBar : He.Bin {
     static construct {
         set_layout_manager_type (typeof (Gtk.BoxLayout));
     }
-
-    ~AppBar () {
-        this.unparent ();
-    }
 }

--- a/lib/Widgets/Avatar.vala
+++ b/lib/Widgets/Avatar.vala
@@ -153,8 +153,6 @@ public class He.Avatar : He.Bin {
         img_blur.add_css_class ("avatar-blur");
         img_blur.halign = Gtk.Align.CENTER;
         img_blur.valign = Gtk.Align.CENTER;
-        
-        label.visible = false;
 
         var ioverlay = new Gtk.Overlay ();
         ioverlay.set_child (img_blur);
@@ -165,6 +163,8 @@ public class He.Avatar : He.Bin {
         label.valign = Gtk.Align.CENTER;
         label.add_css_class ("dim-label");
         label.add_css_class ("avatar-label");
+
+        label.visible = false;
 
         var overlay = new Gtk.Overlay ();
         overlay.set_child (ioverlay);

--- a/lib/Widgets/Badge.vala
+++ b/lib/Widgets/Badge.vala
@@ -87,9 +87,4 @@ public class He.Badge : He.Bin {
         overlay.add_overlay (box);
         overlay.set_parent (this);
     }
-
-    ~Badge () {
-        this.overlay.unparent ();
-        this.box.unparent ();
-    }
 }

--- a/lib/Widgets/Banner.vala
+++ b/lib/Widgets/Banner.vala
@@ -163,9 +163,5 @@ public class He.Banner : He.Bin, Gtk.Buildable {
         this.set_valign (Gtk.Align.START);
         this.set_vexpand (false);
     }
-
-    ~Banner () {
-        this.main_box.unparent ();
-    }
 }
   

--- a/lib/Widgets/ContentBlock.vala
+++ b/lib/Widgets/ContentBlock.vala
@@ -188,10 +188,4 @@ public class He.ContentBlock : He.Bin, Gtk.Buildable {
         box.append(button_box);
         box.set_parent(this);
     }
-
-    ~ContentBlock() {
-        this.info_box.unparent();
-        this.button_box.unparent();
-        this.dispose();
-    }
 }

--- a/lib/Widgets/ContentList.vala
+++ b/lib/Widgets/ContentList.vala
@@ -103,21 +103,6 @@ public class He.ContentList : He.Bin, Gtk.Buildable {
     	base ();
     }
 
-    ~ContentList () {
-        if (list != null) {
-            list.unparent ();
-        }
-        if (text_box != null) {
-            text_box.unparent ();
-        }
-        if (title_label != null) {
-            title_label.unparent ();
-        }
-        if (description_label != null) {
-            description_label.unparent ();
-        }
-    }
-
     construct {
         this.title_label.set_visible (false);
         this.description_label.set_visible (false);

--- a/lib/Widgets/Dialog.vala
+++ b/lib/Widgets/Dialog.vala
@@ -177,11 +177,6 @@ public class He.Dialog : He.Window {
         this.secondary_button = secondary_button;
     }
 
-    ~Dialog() {
-        this.unparent();
-        this.dialog_handle.dispose();
-    }
-
     construct {
         image.valign = Gtk.Align.CENTER;
         title_label.add_css_class ("view-title");

--- a/lib/Widgets/EmptyPage.vala
+++ b/lib/Widgets/EmptyPage.vala
@@ -118,8 +118,4 @@ public class He.EmptyPage : He.Bin {
         this.hexpand = true;
         this.vexpand = true;
     }
-
-    ~EmptyPage() {
-        box.unparent();
-    }
 }

--- a/lib/Widgets/ModifierBadge.vala
+++ b/lib/Widgets/ModifierBadge.vala
@@ -163,8 +163,4 @@ public class He.ModifierBadge : He.Bin {
         this.valign = Gtk.Align.CENTER;
         this.alignment = Alignment.RIGHT;
     }
-
-    ~ModifierBadge() {
-        this._label?.unparent();
-    }
 }

--- a/lib/Widgets/SettingsPage.vala
+++ b/lib/Widgets/SettingsPage.vala
@@ -64,8 +64,4 @@ public class He.SettingsPage : He.Bin, Gtk.Buildable {
     construct {
         box.set_parent (this);
     }
-
-    ~SettingsPage () {
-        this.unparent ();
-    }
 }

--- a/lib/Widgets/SettingsWindow.vala
+++ b/lib/Widgets/SettingsWindow.vala
@@ -111,10 +111,6 @@
         on_pages_changed (0, 0, this.stack.pages.get_n_items ());
     }
 
-    ~SettingsWindow () {
-        this.unparent ();
-    }
-
     private void on_pages_changed (uint position, uint removed, uint added) {
         if (this.stack.pages.get_n_items () <= 1) {
             if (this.switcher.get_parent () != null && this.switcher.get_parent () == this.box) {

--- a/lib/Widgets/Toast.vala
+++ b/lib/Widgets/Toast.vala
@@ -146,10 +146,6 @@ public class He.Toast : He.Bin {
         });
     }
 
-    ~Toast () {
-        get_first_child ().unparent ();
-    }
-
     private void start_timeout () {
         uint duration;
 


### PR DESCRIPTION
This adds a common disposal function to all Gtk.Widget descendants that will loop through all children and remove them on close. All other Model or Widget classes extend Gtk classes which already contain disposal functions.

The only reason to add a new Disposal function is if a widget extends Gtk.Widget itself, in which case it will have to provide it's own disposal.

There's also one extra bug fixed in this MR: lib/Widgets/Avatar.vala (reorder a property that was being called before the widget existed). Make sure that all widgets are defined before properties are added