### PR TITLE
fix: Fix He.Window parent property (#21)

### DIFF
--- a/lib/Models/Window.vala
+++ b/lib/Models/Window.vala
@@ -35,7 +35,6 @@ public class He.Window : Gtk.Window {
         }
         set {
             _parent = value;
-            set_parent (value);
             set_transient_for (value);
         }
     }

--- a/lib/Widgets/AboutWindow.vala
+++ b/lib/Widgets/AboutWindow.vala
@@ -382,7 +382,6 @@ public class He.AboutWindow : He.Window {
     He.Colors color
   ) {
     this.parent = parent;
-    this.transient_for = parent;
     this.app_name = app_name;
     this.app_id = app_id;
     this.version = version;

--- a/lib/Widgets/Dialog.vala
+++ b/lib/Widgets/Dialog.vala
@@ -151,7 +151,6 @@ public class He.Dialog : He.Window {
     public Dialog(bool modal, Gtk.Window? parent, string title, string subtitle, string info, string icon, He.FillButton? primary_button, He.TintButton? secondary_button) {
         this.modal = modal;
         this.parent = parent;
-        this.transient_for = parent;
         this.title = title;
         this.info = info;
         this.icon = icon;
@@ -173,7 +172,7 @@ public class He.Dialog : He.Window {
         info_label.wrap = true;
         info_label.wrap_mode = Pango.WrapMode.WORD;
         info_label.visible = false;
-        
+
         info_box.append(image);
         info_box.append(title_label);
         info_box.append(info_label);


### PR DESCRIPTION
Originally, I thought this was a GTK bug in > 3.8... but then I realized that we shouldn't be calling set_parent in the first place, we just need transient_for :p