### PR TITLE
merge in gsettings-schemas from tau's gschema

### DIFF
--- a/data/com.fyralabs.desktop.appearance.gschema.xml
+++ b/data/com.fyralabs.desktop.appearance.gschema.xml
@@ -1,0 +1,51 @@
+<?xml version="1.0" encoding="utf-8"?>
+<schemalist>
+  <enum id="com.fyralabs.desktop.appearance.ensor-scheme">
+    <value nick="default" value="0"/>
+    <value nick="vibrant" value="1"/>
+    <value nick="muted" value="2"/>
+    <value nick="mono" value="3"/>
+  </enum>
+  <enum id="com.fyralabs.desktop.appearance.contrast-scheme">
+    <value nick="default" value="0"/>
+    <value nick="high" value="1"/>
+    <value nick="low" value="2"/>
+  </enum>
+  <schema path="/com/fyralabs/desktop/appearance/" id="com.fyralabs.desktop.appearance">
+    <key name='ensor-scheme' enum='com.fyralabs.desktop.appearance.ensor-scheme'>
+      <default>'default'</default>
+      <summary>System Ensor Scheme</summary>
+      <description>
+        The preferred Ensor coloring scheme for the user interface.
+      </description>
+    </key>
+    <key name="accent-color" type="s">
+      <default>"#8c56bf"</default>
+      <summary>System Accent Color</summary>
+      <description>
+        The preferred accent color for the user interface.
+      </description>
+    </key>
+    <key name="font-weight" type="d">
+      <default>1.0</default>
+      <summary>System Font Weight</summary>
+      <description>
+        The preferred font weight for the user interface. Makes all text bold or light to the user's choice.
+      </description>
+    </key>
+    <key name="roundness" type="d">
+      <default>1.0</default>
+      <summary>System UI Roundness</summary>
+      <description>
+        The preferred roundness for the user interface. Makes all interface objects as round as the user's choice.
+      </description>
+    </key>
+    <key name="contrast" enum='com.fyralabs.desktop.appearance.contrast-scheme'>
+      <default>'default'</default>
+      <summary>System Contrast</summary>
+      <description>
+        The preferred contrast for the user interface. Makes user interface high or low contrast to the user's choice.
+      </description>
+    </key>
+  </schema>
+</schemalist>

--- a/meson.build
+++ b/meson.build
@@ -107,3 +107,19 @@ endif
 if get_option('gidoc') or get_option('valadoc')
     subdir('doc')
 endif
+
+# GSettings schemas, merged from tau-gsettings-schemas since
+# it's now standard for all Helium-based apps.
+
+settings_schemas = [ 'data/com.fyralabs.desktop.appearance.gschema.xml' ]
+
+gnome.compile_schemas(depend_files: files(settings_schemas))
+
+schemas_dir = get_option('prefix') / get_option('datadir') / 'glib-2.0' / 'schemas'
+
+install_data(settings_schemas, install_dir: schemas_dir)
+
+meson.add_install_script('glib-compile-schemas', schemas_dir)
+
+
+# end schema stuff


### PR DESCRIPTION
Now that Fusebox has a hard dependency on it (and most Helium apps won't function properly without it), we should move this to libhelium itself. No more `tau-gsettings-schemas`. Since that package literally only has this one schema file and nothing else (see https://github.com/tau-OS/tau-gsettings-schemas/issues/1)